### PR TITLE
Renamed Timer object

### DIFF
--- a/source/js/Timer.js
+++ b/source/js/Timer.js
@@ -73,4 +73,4 @@ async function sessionTest() {
 sessionTest();
 */
 
-export default Timer
+export default Timer;


### PR DESCRIPTION
Renamed from timer_object.js to Timer.js
Also added the `export default Timer;` to the end of the file. 