### PR TITLE
Potato Image and text fixed along with some refactoring

### DIFF
--- a/source/app.html
+++ b/source/app.html
@@ -82,7 +82,7 @@
             <template id="timer-template">
                 <div class="timer-container position-relative mh-100 mw-100">
                     <img class="timer-image w-100 h-100 position-absolute top-50 start-50 translate-middle" src="./img/green-tomato.svg">
-                    <div class="timer-text w-100 h-25 text-center position-absolute top-50 start-50 translate-middle">
+                    <div class="timer-text w-100 h-0 text-center position-absolute top-50 start-50 translate-middle">
                         <span id="minutes"></span>
                         :
                         <span id="seconds"></span>

--- a/source/scss/main.scss
+++ b/source/scss/main.scss
@@ -44,11 +44,12 @@ body {
 .btn {
     border-radius: 2.5rem;
     font-size: $h5-font-size;
+    @include font-size($h5-font-size);
 }
 
 .btn-lg {
     padding: map-get($spacers, 2) map-get($spacers, 5);
-    font-size: $h4-font-size;
+    @include font-size($h4-font-size);
 }
 
 .btn-block {
@@ -82,7 +83,8 @@ input:focus {
 
 .subtitle {
     color: $primary;
-    font-size: 2.5rem;
+    // font-size: 2.5rem;
+    @include font-size($h2-font-size * 1.5);
     font-weight: 600;
     text-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
 }
@@ -102,7 +104,8 @@ input:focus {
 
     .start-input {
         width: 100%;
-        font-size: $h3-font-size;
+        // font-size: $h3-font-size;
+        @include font-size($h3-font-size);
         padding: map-get($spacers, 3);
     }
 
@@ -133,7 +136,8 @@ footer {
     bottom: 0;
     width: 100%;
     padding: 1.5rem 0;
-    font-size: 1.25rem;
+    // font-size: 1.25rem;
+    @include font-size($h5-font-size);
 }
 
 footer * {
@@ -163,7 +167,7 @@ footer > .container {
 
 .task-list-container {
     border-radius: 2.5rem 2.5rem 0 0;
-    font-size: $h5-font-size;
+    @include font-size($h5-font-size);
     background-color: white;
     height: 100%;
     padding: map-get($spacers, 5);
@@ -248,8 +252,8 @@ footer > .container {
 
 .timer-text {
     // @extend %heading;
-    // @include font-size($h1-font-size * 1.5);
-    font-size: $h1-font-size * 1.5;
+    @include font-size($h1-font-size * 1.5);
+    // font-size: $h1-font-size * 1.5;
     width: 100%;
 }
 


### PR DESCRIPTION
closes #66 

refactored main.scss to follow bootstrap standards of using @include font-size(<font-size>)
Timer image and font should be better looking now.