### PR TITLE
reposition ViewOnlyTaskList on screen resize

### DIFF
--- a/source/js/ViewOnlyTaskList.js
+++ b/source/js/ViewOnlyTaskList.js
@@ -48,6 +48,10 @@ class ViewOnlyTaskList extends HTMLElement {
    */
   connectedCallback() {
     this.position();
+
+    window.addEventListener('resize', () => {
+      this.position();
+    });
   }
 
   render() {


### PR DESCRIPTION
closes #87. added an event listener to the window to just call ViewOnlyTaskList.position() which dynamically updates the position.